### PR TITLE
Add a variation for the fedoraproject paste site.

### DIFF
--- a/caste
+++ b/caste
@@ -35,6 +35,7 @@ class Test_Transform(unittest.TestCase):
             ('https://dpaste.de/K5Ey', 'https://dpaste.de/K5Ey/raw'),
             ('https://gitlab.com/snippets/1681734', 'https://gitlab.com/snippets/1681734/raw'),
             ('https://paste.apache.org/TPFl', 'https://paste.apache.org/TPFl?raw'), # used to auto-provide raw to curl
+            ('https://paste.fedoraproject.org/paste/mjRMy5MLpnenYX9vJqQVaw', 'https://paste.fedoraproject.org/paste/mjRMy5MLpnenYX9vJqQVaw/raw'),
         )
         for x, y in pairs:
             f_x = transform(x)
@@ -64,6 +65,7 @@ REPLACEMENTS = (
     (r'(://dpaste.de)/([0-9A-Za-z]{4,})/?$', r'\1/\2/raw'),
     (r'(://gitlab.com/snippets/[0-9]{4,})/?$', r'\1/raw'),
     (r'(://paste.apache.org)/([0-9A-Za-z]{4,})/?$', r'\1/\2?raw'),
+    (r'(://paste.fedoraproject.org)/(paste/[^/]{4,})/?$', r'\1/\2/raw'),
 )
 REPLACEMENTS = tuple(
     (re.compile(original), modified) for original, modified in REPLACEMENTS


### PR DESCRIPTION
Just ran across this in #fedora tonight, looks like fedoraproject changed services?  Left he old variant since I couldn't definitely confirm it didn't still exist anywhere. 